### PR TITLE
Fix Mezzanine issue 159 - Django 1.4 - filter_horizontal broken

### DIFF
--- a/grappelli_safe/static/grappelli/css/widgets.css
+++ b/grappelli_safe/static/grappelli/css/widgets.css
@@ -65,7 +65,7 @@
     width: 698px;
 }
 .selector h2 + select {
-    display: none; position: relative; top: -1px;
+    position: relative; top: -1px;
     border-top: none;
 }
 


### PR DESCRIPTION
Haven't tested to see if there are unintended consequences to removing
display: none; from .selector h2 + select in widgets.css but it does
fix the problem.

https://github.com/stephenmcd/mezzanine/issues/159
