### PR TITLE
mezzanine TemplateSyntaxError at /password_reset/

### DIFF
--- a/grappelli_safe/templates/registration/password_reset_email.html
+++ b/grappelli_safe/templates/registration/password_reset_email.html
@@ -4,7 +4,7 @@
 
 {% trans "Please go to the following page and choose a new password:" %}
 {% block reset_link %}
-{{ protocol }}://{{ domain }}{% url "django.contrib.auth.views.password_reset_confirm" uidb36=uid, token=token %}
+{{ protocol }}://{{ domain }}{% url "django.contrib.auth.views.password_reset_confirm" uidb36=uid token=token %}
 {% endblock %}
 {% trans "Your username, in case you've forgotten:" %} {{ user.username }}
 


### PR DESCRIPTION
bug fix as per https://github.com/django/django/commit/dafc077e4a i.e. after i removed the comma mezzanine http://127.0.0.1:8000/password_reset/ works

sorry if this is not the way to propose bugfix, but this is my first time on github

hope this helps,

kompir
