### PR TITLE
Normalized jsi18n links.

### DIFF
--- a/grappelli_safe/templates/admin/change_form.html
+++ b/grappelli_safe/templates/admin/change_form.html
@@ -6,7 +6,8 @@
 <!-- JAVASCRIPTS -->
 {% block javascripts %}
     {{ block.super }}
-    <script type="text/javascript" src="../../../jsi18n/"></script>
+    {% url admin:jsi18n as jsi18nurl %}
+    <script type="text/javascript" src="{{ jsi18nurl|default:"../../../jsi18n/" }}"></script>
     {{ media }}
     {% if inline_admin_formsets %}
         <script type="text/javascript" src="{% admin_media_prefix %}js/admin/Inline.js"></script>

--- a/grappelli_safe/templates/admin/change_list.html
+++ b/grappelli_safe/templates/admin/change_list.html
@@ -15,7 +15,8 @@
 
 <!-- JAVASCRIPTS -->
 {% block javascripts %}
-    <script type="text/javascript" src="../../jsi18n/"></script>
+    {% url admin:jsi18n as jsi18nurl %}
+    <script type="text/javascript" src="{{ jsi18nurl|default:"../../jsi18n/" }}"></script>
     {{ block.super }}
     {{ media|use_grappelli_media }}
     <script type="text/javascript" src="{% admin_media_prefix %}js/admin/Changelist.js"></script>


### PR DESCRIPTION
These URLs are necessary when utilizing admin add-ons such as django-guardian.
