### PR TITLE
Make sure the magnifying glass appears on inline extra fields.

### DIFF
--- a/grappelli_safe/templates/admin/includes/fieldset_inline.html
+++ b/grappelli_safe/templates/admin/includes/fieldset_inline.html
@@ -12,7 +12,7 @@
               {% if field.is_checkbox %}
                   {{ field.field }}{{ field.label_tag }}
               {% else %}
-                  {{ field.label_tag }}{{ field.field }}
+                  {{ field.label_tag }}{{ field.field }} &nbsp;
               {% endif %}
           {% endif %}
           {% if field.field.field.help_text %}<p class="help">{{ field.field.field.help_text|safe }}</p>{% endif %}


### PR DESCRIPTION
This hack ensures the magnifying glass widget displays on extra inline fields.

Here is an image of the manifestation: http://imgur.com/oGUKa
