### PR TITLE
Ensure the spyglass appears on empty raw_id_fields.

### DIFF
--- a/grappelli_safe/templates/admin/includes/fieldset.html
+++ b/grappelli_safe/templates/admin/includes/fieldset.html
@@ -12,7 +12,7 @@
               {% if field.is_checkbox %}
                   {{ field.field }}{{ field.label_tag }}
               {% else %}
-                  {{ field.label_tag }}{{ field.field }}
+                  {{ field.label_tag }}{{ field.field }} &nbsp;
               {% endif %}
           {% endif %}
           {% if field.field.field.help_text %}<p class="help">{{ field.field.field.help_text|safe }}</p>{% endif %}


### PR DESCRIPTION
This ensures there is some content in the field html. When it's empty, such as when adding a new object with raw_id_fields the spyglass doesn't appear.
