### PR TITLE
Removed undefined templatetags

### DIFF
--- a/grappelli_safe/templates/admin/index.html
+++ b/grappelli_safe/templates/admin/index.html
@@ -149,9 +149,4 @@
     </div>
 </div>
 
-<!-- NAVIGATION -->
-{% block extendedsidebar %}
-{% get_navigation user %}
-{% endblock %}
-
 {% endblock %}


### PR DESCRIPTION
I have removed the usage of `get_navigation` templatetag in templates/admin/index.html This was breaking manage.py compress in mezzanine.
