### PR TITLE
Hide the delete form if there are protected objects.

### DIFF
--- a/grappelli_safe/templates/admin/delete_confirmation.html
+++ b/grappelli_safe/templates/admin/delete_confirmation.html
@@ -16,13 +16,23 @@
 
 <!-- CONTENT -->
 {% block content %}
-{% if perms_lacking %}
-    <p>{% blocktrans with object as escaped_object %}Deleting the {{ object_name }} '{{ escaped_object }}' would result in deleting related objects, but your account doesn't have permission to delete the following types of objects:{% endblocktrans %}</p>
-    <ul>
-    {% for obj in perms_lacking %}
-        <li>{{ obj }}</li>
-    {% endfor %}
-    </ul>
+{% if perms_lacking or protected %}
+    {% if perms_lacking %}
+        <p>{% blocktrans with object as escaped_object %}Deleting the {{ object_name }} '{{ escaped_object }}' would result in deleting related objects, but your account doesn't have permission to delete the following types of objects:{% endblocktrans %}</p>
+        <ul>
+        {% for obj in perms_lacking %}
+            <li>{{ obj }}</li>
+        {% endfor %}
+        </ul>
+    {% endif %}
+    {% if protected %}
+        <p>{% blocktrans with object as escaped_object %}Deleting the {{ object_name }} '{{ escaped_object }}' would require deleting the following protected related objects:{% endblocktrans %}</p>
+        <ul>
+        {% for obj in protected %}
+            <li>{{ obj }}</li>
+        {% endfor %}
+        </ul>
+    {% endif %}
 {% else %}
     <p>{% blocktrans with object as escaped_object %}Are you sure you want to delete the {{ object_name }} "{{ escaped_object }}"? All of the following related items will be deleted:{% endblocktrans %}</p>
     <ul>{{ deleted_objects|unordered_list }}</ul>


### PR DESCRIPTION
The delete confirmation page musn't show the delete form if there are protected objects.

Here is similar code from [grappelli](https://github.com/sehmaschine/django-grappelli/blob/master/grappelli/templates/admin/delete_confirmation.html#L25-L44) and from [django](https://github.com/django/django/blob/master/django/contrib/admin/templates/admin/delete_confirmation.html#L16-L33).
