### PR TITLE
Wrap fieldsets and inlines in blocks.

### DIFF
--- a/grappelli_safe/templates/admin/change_form.html
+++ b/grappelli_safe/templates/admin/change_form.html
@@ -62,16 +62,20 @@
             {% endif %}
 
             <!-- Fieldsets -->
+            {% block field_sets %}
             {% for fieldset in adminform %}
             {% include "admin/includes/fieldset.html" %}
             {% endfor %}
+            {% endblock %}
 
             {% block after_field_sets %}{% endblock %}
 
             <!-- Inlines -->
+            {% block inline_field_sets %}
             {% for inline_admin_formset in inline_admin_formsets %}
             {% include inline_admin_formset.opts.template %}
             {% endfor %}
+            {% endblock %}
 
             {% block after_related_objects %}{% endblock %}
 


### PR DESCRIPTION
Follow the tradition of Django official template and grappelli to use predefined block wrappers. Users can then extend these blocks to for example customize the ordering, https://groups.google.com/d/msg/django-users/yUq2Nvx_4eM/30_EkjePrOAJ
