### PR TITLE
Removed extra fieldset in add_form.html

### DIFF
--- a/grappelli_safe/templates/admin/auth/user/add_form.html
+++ b/grappelli_safe/templates/admin/auth/user/add_form.html
@@ -5,29 +5,4 @@
 
 <p>{% trans "First, enter a username and password. Then, you'll be able to edit more user options." %}</p>
 
-<fieldset class="module aligned">
-
-<div class="form-row">
-  {{ form.username.errors }}
-  {# TODO: get required class on label_tag #}
-  <label for="id_username" class="required">{% trans 'Username' %}:</label> {{ form.username }}
-  <p class="help">{{ form.username.help_text }}</p>
-</div>
-
-<div class="form-row">
-  {{ form.password1.errors }}
-  {# TODO: get required class on label_tag #}
-  <label for="id_password1" class="required">{% trans 'Password' %}:</label> {{ form.password1 }}
-</div>
-
-<div class="form-row">
-  {{ form.password2.errors }}
-  {# TODO: get required class on label_tag #}
-  <label for="id_password2" class="required">{% trans 'Password (again)' %}:</label> {{ form.password2 }}
-  <p class="help">{% trans 'Enter the same password as above, for verification.' %}</p>
-</div>
-
-<script type="text/javascript">document.getElementById("id_username").focus();</script>
-
-</fieldset>
 {% endblock %}


### PR DESCRIPTION
Issue #37 in master branch

removed fieldset that displayed username/password/verify password fields within the after_fields_sets block
because now in change_form.html (block field_sets), which add_form.html overrides, the username, password etc fields are being displayed.  Thus on an initial add of a user, two sets of fields were being displayed and
the bottom one was unusable as well.

add_form.html now merely adds an explanation to the user why only username,etc are settable
