### PR TITLE
breadcrumbs admin with many app hide 'add button'

### DIFF
--- a/grappelli_safe/static/grappelli/css/base.css
+++ b/grappelli_safe/static/grappelli/css/base.css
@@ -259,7 +259,7 @@ ul#bookmarks-listing li:last-child a {
 ------------------------------------------------------------------------------------------------------ */
 
 div.breadcrumbs {
-    position: fixed; top: 30px; z-index: 1000;
+    position: relative; top: 30px; z-index: 1000;
     width: 100%;
     padding: 3px 8px 3px 15px;
     color: #666; font-size: 11px; font-weight: normal; text-align: left;


### PR DESCRIPTION
when admin has many apps breadcrumbs menus create multiple lines and hide 'add' button, changing this line to relative instead fixed it doesnt happen
