### PR TITLE
Fix broken select all functionality

### DIFF
--- a/grappelli_safe/templates/admin/actions.html
+++ b/grappelli_safe/templates/admin/actions.html
@@ -6,7 +6,7 @@
         <ul>
             <li class="action-counter"><span class="action-counter">{{ selection_note }}</span></li>
             {% if cl.result_count != cl.result_list|length %}
-                <li class="all"><span class="all">{{ selection_note_all }}</span></li>
+                <li class="all">{{ selection_note_all }}</li>
                 <li class="question"><a href="javascript:;" title="{% trans "Click here to select the objects across all pages" %}">{% blocktrans with cl.result_count as total_count %}Select all {{ total_count }} {{ module_name }}{% endblocktrans %}</a></li>
                 <li class="clear-selection"><a href="javascript://" class="clear">{% trans "Clear selection" %}</a></li>
             {% endif %}

--- a/grappelli_safe/templates/admin/change_list.html
+++ b/grappelli_safe/templates/admin/change_list.html
@@ -39,7 +39,7 @@
             $("tr input.action-select").actions({
                 allContainer: "div.actions li.all",
                 acrossQuestions: "div.actions li.question",
-                acrossClears: "div.actions li.clear"
+                acrossClears: "div.actions li.clear-selection"
             });
         });
     </script>


### PR DESCRIPTION
I'm not sure how it got broken or if it ever worked, but now it should work.

If you need to test this, you can set `list_per_page = 1` on a ModelAdmin to force pagination.

Thanks!