### PR TITLE
Trivial addition of new block to inline templates for cleaner extending

### DIFF
--- a/grappelli_safe/templates/admin/edit_inline/stacked.html
+++ b/grappelli_safe/templates/admin/edit_inline/stacked.html
@@ -3,9 +3,11 @@
 <div class="inline-group inline-stacked{% if inline_admin_formset.opts.sortable %} sortable{% endif %}{% if inline_admin_formset.opts.classes %} {{ inline_admin_formset.opts.classes|join:" " }}{% endif %}" name="inlinegroup">
     <h2>{{ inline_admin_formset.opts.verbose_name_plural|title }}</h2>
     <ul class="inline-item-tools">
-        <li><a href="javascript://" class="openhandler" title="{% trans 'Open All Items' %}"></a></li>
-        <li><a href="javascript://" class="closehandler" title="{% trans 'Close All Items' %}"></a></li>
-        {% if inline_admin_formset.opts.allow_add %}<li><a href="javascript://" class="addhandler" title="{% trans 'Add Item' %}"></a></li>{% endif %}
+        {% block inline-item-tools %}
+            <li><a href="javascript://" class="openhandler" title="{% trans 'Open All Items' %}"></a></li>
+            <li><a href="javascript://" class="closehandler" title="{% trans 'Close All Items' %}"></a></li>
+            {% if inline_admin_formset.opts.allow_add %}<li><a href="javascript://" class="addhandler" title="{% trans 'Add Item' %}"></a></li>{% endif %}
+        {% endblock %}
     </ul>
     {{ inline_admin_formset.formset.management_form }}
     {{ inline_admin_formset.formset.non_form_errors }}

--- a/grappelli_safe/templates/admin/edit_inline/tabular.html
+++ b/grappelli_safe/templates/admin/edit_inline/tabular.html
@@ -3,7 +3,9 @@
 <div class="inline-group inline-tabular{% if inline_admin_formset.opts.sortable %} sortable{% endif %}{% if inline_admin_formset.opts.classes %} {{ inline_admin_formset.opts.classes|join:" " }}{% endif %}" name="inlinegrouptabular">
     <h2>{{ inline_admin_formset.opts.verbose_name_plural|capfirst }}</h2>
     <ul class="inline-item-tools">
-        {% if inline_admin_formset.opts.allow_add %}<li><a href="javascript://" class="addhandler" title="{% trans 'Add Item' %}"></a></li>{% endif %}
+        {% block inline-item-tools %}
+            {% if inline_admin_formset.opts.allow_add %}<li><a href="javascript://" class="addhandler" title="{% trans 'Add Item' %}"></a></li>{% endif %}
+        {% endblock %}
     </ul>
     {{ inline_admin_formset.formset.management_form }}
     {{ inline_admin_formset.formset.non_form_errors }}


### PR DESCRIPTION
The `item-inline-tools` area is a useful spot in the inline templates for overriding 'actions' for an inline, so add a template block to make it easy to extend in custom template.