### PR TITLE
Add missing 'object-tools-items' block to change_form.html

### DIFF
--- a/grappelli_safe/templates/admin/change_form.html
+++ b/grappelli_safe/templates/admin/change_form.html
@@ -38,8 +38,11 @@
     {% block object-tools %}
     {% if change %}
     {% if not is_popup %}
-    <ul class="object-tools"><li><a href="history/">{% trans "History" %}</a></li>
-        {% if has_absolute_url %}<li><a href="../../../r/{{ content_type_id }}/{{ object_id }}/" class="focus" target="_blank">{% trans "View on site" %}</a></li>{% endif%}
+    <ul class="object-tools">
+        {% block object-tools-items %}
+            <li><a href="history/">{% trans "History" %}</a></li>
+            {% if has_absolute_url %}<li><a href="../../../r/{{ content_type_id }}/{{ object_id }}/" class="focus" target="_blank">{% trans "View on site" %}</a></li>{% endif%}
+        {% endblock %}
     </ul>
     {% endif %}
     {% endif %}


### PR DESCRIPTION
This block exists in Django's default admin templates and is quite handy since it lets you append or prepend to the list which is much more friendly to template extending.
