### PR TITLE
Preserve admin filters on object delete

### DIFF
--- a/grappelli_safe/templates/admin/delete_confirmation.html
+++ b/grappelli_safe/templates/admin/delete_confirmation.html
@@ -1,7 +1,7 @@
 {% extends "admin/base_site.html" %}
 
 <!-- LOADING -->
-{% load i18n %}
+{% load i18n admin_urls %}
 
 <!-- BREADCRUMBS -->
 {% block breadcrumbs %}
@@ -38,7 +38,8 @@
     <ul>{{ deleted_objects|unordered_list }}</ul>
     <form action="" method="post">{% csrf_token %}
         <div class="submit-row">
-            <p class="cancellink-box"><a href="../" class="cancellink">{% trans "Cancel" %}</a></p>
+            {% url opts|admin_urlname:'change' object.pk|admin_urlquote as object_url %}
+            <p class="cancellink-box"><a href="{% add_preserved_filters object_url %}" class="cancellink">{% trans "Cancel" %}</a></p>
             <input type="hidden" name="post" value="yes" />
             <input type="submit" value="{% trans "Yes, I'm sure" %}" class="default" />
         </div>

--- a/grappelli_safe/templates/admin/submit_line.html
+++ b/grappelli_safe/templates/admin/submit_line.html
@@ -1,7 +1,10 @@
-{% load i18n %}
+{% load i18n admin_urls %}
 
 <div class="submit-row" {% if is_popup %}style="overflow: auto;"{% endif %}>
-    {% if show_delete_link %}<p class="deletelink-box"><a href="delete/" class="deletelink">{% trans "Delete" %}</a></p>{% endif %}
+    {% if show_delete_link %}
+        {% url opts|admin_urlname:'delete' original.pk|admin_urlquote as delete_url %}
+        <p class="deletelink-box"><a href="{% add_preserved_filters delete_url %}" class="deletelink">{% trans "Delete" %}</a></p>
+    {% endif %}
     {% if show_save %}<input type="submit" value="{% trans 'Save' %}" class="default" name="_save" {{ onclick_attrib }}/>{% endif %}
     {% if show_save_as_new %}<input class="change-view-save-new" type="submit" value="{% trans 'Save as new' %}" name="_saveasnew" {{ onclick_attrib }}/>{%endif%}
     {% if show_save_and_add_another %}<input class="change-view-save-another" type="submit" value="{% trans 'Save and add another' %}" name="_addanother" {{ onclick_attrib }} />{% endif %}


### PR DESCRIPTION
Preserve current filters when deleting an object in admin (including the cancel button). Was ported from [Django fix](https://github.com/django/django/commit/c86a9b63984f6692d478f6f70e3c78de4ec41814#diff-75c7039c514bc8378b82be100e1b586c) in 1.6.
