### PR TITLE
Fix for the related-objects admin change in django 1.8

### DIFF
--- a/grappelli_safe/templates/admin/change_form.html
+++ b/grappelli_safe/templates/admin/change_form.html
@@ -56,6 +56,27 @@
             <!-- Submit-Row -->
             {% if save_on_top %}{% block submit_buttons_top %}{% submit_row %}{% endblock %}{% endif %}
 
+            <!-- Related-objects js that was brought in with Django 1.8 (merge from grappelli) -->
+            {% block admin_change_form_document_ready %}
+            <script type="text/javascript">
+                (function($) {
+                    $(document).ready(function() {
+                        $('.add-another').click(function(e) {
+                            e.preventDefault();
+                            showAddAnotherPopup(this);
+                        });
+                        $('.related-lookup').click(function(e) {
+                            e.preventDefault();
+                            showRelatedObjectLookupPopup(this);
+                        });
+                    {% if adminform and add %}
+                        $('form#{{ opts.model_name }}_form :input:visible:enabled:first').focus()
+                    {% endif %}
+                    });
+                })(django.jQuery);
+            </script>
+            {% endblock %}
+
             <!-- Errors -->
             {% if errors %}
             <p class="errornote">


### PR DESCRIPTION
Django 1.8 separated the Javascript and HTML for related objects from the admin templates (by removing the `onclick` and instead adding a jquery event handler), meaning clicking a related item lookup (the little magnifying glass) now does nothing. This is used with (among a few others), [`raw_id_fields`](https://docs.djangoproject.com/en/1.8/ref/contrib/admin/#django.contrib.admin.ModelAdmin.raw_id_fields).

Upstream grappelli's solution to this is to bring in the new Javascript that Django added, and I have mirrored that here. See [here](https://github.com/ngzhian/django-grappelli/commit/cfce21386a295acb1c3ea0bc1ebb59f49be40683) for more details.

I have tested on Django 1.8 (the related item lookup now pops up), and Django 1.7 seems unaffected with this change.

You can test the old and new behaviour by creating a new model:

```python
class RelatedTest(models.Model):
    product = models.OneToOneField('shop.Product')

class RelatedAdmin(admin.ModelAdmin):
    raw_id_fields = ('product',)

admin.site.register(RelatedTest, RelatedAdmin)
```

Now go to the admin and add a new `RelatedTest` item: click the search magnifying glass icon next to product and you will be taken to the `Product` changelist page, instead of the related item lookup popup appearing.

Applying this PR restores the original behaviour.