### PR TITLE
Replace prefix's in tabular inline forms.

### DIFF
--- a/grappelli_safe/static/grappelli/css/forms.css
+++ b/grappelli_safe/static/grappelli/css/forms.css
@@ -541,4 +541,9 @@ td ul.errorlist li {
     color: #999; font-size: 11px;
 }
 
+/* Dynamic Form Templates
+------------------------------------------------------------------------------------------------------ */
 
+.inline-tabular .empty-form {
+    display: none;
+}

--- a/grappelli_safe/templates/admin/edit_inline/tabular.html
+++ b/grappelli_safe/templates/admin/edit_inline/tabular.html
@@ -20,7 +20,7 @@
             <div class="form-cell">&nbsp;</div>
         </div>
         {% for inline_admin_form in inline_admin_formset %}
-        <div class="inline-related{% if inline_admin_form.original or inline_admin_form.show_url %} has_original{% endif %}"> <!-- tbody, sortable items -->
+        <div class="inline-related{% if inline_admin_form.original or inline_admin_form.show_url %} has_original{% endif %}{% if forloop.last %} empty-form{% endif %}"> <!-- tbody, sortable items -->
             <!-- errors -->
             {% if inline_admin_form.form.non_field_errors %}
                 <div>{{ inline_admin_form.form.non_field_errors }}</div>


### PR DESCRIPTION
In upstream django this is handled by admin/js/inlines.js.

This is part of the fix for Mezzanine's issue #1366 (duplicate site
permissions inlines).

I should have noted in [Mezzanine #1379](https://github.com/stephenmcd/mezzanine/pull/1379) that I've yet to get the site permissions properly working from the admin interface, so I can't really confirm whether these fixes actually work. But I believe this should do it.