### PR TITLE
Remove browser hack that makes inputs look ugly

### DIFF
--- a/grappelli_safe/static/grappelli/css/forms.css
+++ b/grappelli_safe/static/grappelli/css/forms.css
@@ -163,16 +163,6 @@ input[type=text], input[type=password], input[type=email], input[type=url] {
     padding: 5px 3px 4px;
     height: 14px;
 }
-/*  Webkit browser hack: apply same horizontal padding as in moz browsers
-    Moz Browsers have a default horizontal padding of 3px in input[type=submit] */
-@media screen and (-webkit-min-device-pixel-ratio:0) {
-    input[type=text], input[type=password], input[type=email], input[type=url] {
-        padding: 0 3px 4px;
-        height: 19px;
-        line-height: 25px !important;
-    }
-}
-
 
 /*  URL .................................................... */
 


### PR DESCRIPTION
Tested on Chrome & Firefox - see before and after screenshots.

before:
![2015-10-07-110052_369x111_scrot](https://cloud.githubusercontent.com/assets/59292/10341492/fb9961e6-6ce2-11e5-97e7-ad301869cb90.png)

after:
![2015-10-07-110103_372x115_scrot](https://cloud.githubusercontent.com/assets/59292/10341498/feebf340-6ce2-11e5-9079-582b0503e64d.png)
