### PR TITLE
Fix popup query parameter in changelist template

### DIFF
--- a/grappelli_safe/templates/admin/change_list.html
+++ b/grappelli_safe/templates/admin/change_list.html
@@ -132,7 +132,7 @@
                             <h2>{% trans 'Results' %}</h2>
                             <div class="form-row">
                                 <p>{% blocktrans with cl.result_count as counter %}{{ counter }} found{% endblocktrans %}</p>
-                                <a href="?{% if cl.is_popup %}pop=1{% endif %}">{% blocktrans with cl.full_result_count as full_result_count %}{{ full_result_count }} total{% endblocktrans %}</a>
+                                <a href="?{% if cl.is_popup %}_popup=1{% endif %}">{% blocktrans with cl.full_result_count as full_result_count %}{{ full_result_count }} total{% endblocktrans %}</a>
                             </div>
                         </div>
                         {% endifnotequal %}


### PR DESCRIPTION
Same fix as [this commit](https://github.com/sehmaschine/django-grappelli/commit/a2eb5679ffd127c7341a3a4cfc623ab91e5b2f03) from Grappelli upstream