### PR TITLE
Use slugify on tabular header class

### DIFF
--- a/grappelli_safe/templates/admin/edit_inline/tabular.html
+++ b/grappelli_safe/templates/admin/edit_inline/tabular.html
@@ -14,7 +14,7 @@
         <div class="legend"> <!-- table header -->
             {% for field in inline_admin_formset.fields %}
                 {% if not field.widget.is_hidden %}
-                    <div class="form-cell {{ field.label|lower }}">{{ field.label|capfirst }}</div>
+                    <div class="form-cell {{ field.label|lower|slugify }}">{{ field.label|capfirst }}</div>
                 {% endif %}
             {% endfor %}
             <div class="form-cell">&nbsp;</div>


### PR DESCRIPTION
This fix is [picked](https://github.com/sehmaschine/django-grappelli/commit/751d3e81ee7afcba6ad715d757fca68a74922037) from upstream Grappelli and fixes an issue with CSS classes that are set on the headers for tabular inlines.

Without the slugify field labels with spaces get applied verbatim into the class attribute leading to things like 'Total price' from Cartridge turning into class="form-cell total price". Defeats the benefit of having special classes on the table headers, as well as having issues if there are special characters in the label name (like apostrophes).
