### PR TITLE
Remove overzealous CSS selector for changelist filters

### DIFF
--- a/grappelli_safe/static/grappelli/css/changelist.css
+++ b/grappelli_safe/static/grappelli/css/changelist.css
@@ -315,8 +315,7 @@ ul.date_hierarchy {
     border-top: 1px solid #fff;
     border-bottom: 1px solid #e0e0e0;
 }
-#changelist-filter ul li:last-child, 
-#changelist-filter ul li:last-child *, 
+#changelist-filter ul li:last-child,
 #changelist-filter .filterset:last-child ul {
     border-bottom: none;
     -moz-border-radius-bottomleft: 4px; -webkit-border-bottom-left-radius: 4px; border-bottom-left-radius: 4px;


### PR DESCRIPTION
I'm working on a reusable app to add result counts to the filters on the changelist page and ran into an overzealous CSS selector in grappelli-safe. It selects all children of the last filter and tweaks rounding the bottom border, but there doesn't seem to be an actual use, the CSS selector isn't used in grappelli-safe's rendering of changelist filters.

It does, however, muck with anything you put inside of a filter, like the result count badges I'm adding:
<img width="213" alt="" src="https://cloud.githubusercontent.com/assets/5820654/11965848/5aacd140-a8ac-11e5-867d-f723fb42eb00.png">

Since the CSS selector isn't used it would be nice to remove it so that this works out of the box without some ugly CSS hacks.