### PR TITLE
Add hidden CSS class for admin

### DIFF
--- a/grappelli_safe/static/grappelli/css/forms.css
+++ b/grappelli_safe/static/grappelli/css/forms.css
@@ -61,7 +61,9 @@ fieldset > div:last-child {
     border-bottom: 1px solid #d4d4d4 !important;
 }
 
-
+.hidden {
+    display: none;
+}
 
 
 /* Labels & Other Typographic Elements in Forms


### PR DESCRIPTION
Add in the `hidden` CSS class which appears to have been [added in Django 1.7](https://github.com/django/django/blob/1.7/django/contrib/admin/static/admin/css/forms.css#L21) to ensure that hidden fields in admin are appropriately hidden in all versions of Django.