### PR TITLE
Replace references to _meta attribute "module_name" with "model_name"

### DIFF
--- a/grappelli_safe/templates/admin/auth/user/change_password.html
+++ b/grappelli_safe/templates/admin/auth/user/change_password.html
@@ -14,7 +14,7 @@
 </div>
 {% endif %}{% endblock %}
 {% block content %}<div id="content-main">
-<form action="{{ form_url }}" method="post" id="{{ opts.module_name }}_form">{% csrf_token %}{% block form_top %}{% endblock %}
+<form action="{{ form_url }}" method="post" id="{{ opts.model_name }}_form">{% csrf_token %}{% block form_top %}{% endblock %}
 <div>
 {% if is_popup %}<input type="hidden" name="_popup" value="1" />{% endif %}
 {% if form.errors %}

--- a/grappelli_safe/templates/admin/change_form.html
+++ b/grappelli_safe/templates/admin/change_form.html
@@ -49,7 +49,7 @@
     {% endif %}
     {% endblock %}
 
-    <form {% if has_file_field %}enctype="multipart/form-data" {% endif %}action="{{ form_url }}" method="post" id="{{ opts.module_name }}_form">{% csrf_token %}{% block form_top %}{% endblock %}
+    <form {% if has_file_field %}enctype="multipart/form-data" {% endif %}action="{{ form_url }}" method="post" id="{{ opts.model_name }}_form">{% csrf_token %}{% block form_top %}{% endblock %}
         <div>
             <!-- Popup Hidden Field -->
             {% if is_popup %}<input type="hidden" name="_popup" value="1" />{% endif %}


### PR DESCRIPTION
``Options.module_name`` was deprecated in Django 1.6 in favour of ``Options.model_name``, and has subsequently been removed. It's referred to in a couple of templates to generate ids for forms.

See https://code.djangoproject.com/ticket/19689