### PR TITLE
Hide empty template form in stacked inlines as well

### DIFF
--- a/grappelli_safe/static/grappelli/css/forms.css
+++ b/grappelli_safe/static/grappelli/css/forms.css
@@ -536,6 +536,6 @@ td ul.errorlist li {
 /* Dynamic Form Templates
 ------------------------------------------------------------------------------------------------------ */
 
-.inline-tabular .empty-form {
+.empty-form {
     display: none;
 }

--- a/grappelli_safe/templates/admin/edit_inline/stacked.html
+++ b/grappelli_safe/templates/admin/edit_inline/stacked.html
@@ -13,7 +13,7 @@
     {{ inline_admin_formset.formset.non_form_errors }}
     <div class="items"> <!-- sortable container -->
         {% for inline_admin_form in inline_admin_formset %}
-        <div class="inline-related collapse-closed{% if inline_admin_form.original or inline_admin_form.show_url %} has_original{% endif %}"> <!-- sortable items -->
+        <div class="inline-related collapse-closed{% if inline_admin_form.original or inline_admin_form.show_url %} has_original{% endif %}{% if forloop.last %} empty-form{% endif %}"> <!-- sortable items -->
             <!-- headline, original, delete/link/sort -->
             <h3>
                 {% for fieldset in inline_admin_form %}


### PR DESCRIPTION
This rounds out the fix in #56 to mirror Django by including the `empty-form` class on the final form in stacked inlines as well as tabular, and similarly broadens the corresponding CSS rule.