### PR TITLE
allows for a stacked inline to use inline_classes

### DIFF
--- a/grappelli_safe/static/grappelli/js/admin/CollapsedInlineFieldsets.js
+++ b/grappelli_safe/static/grappelli/js/admin/CollapsedInlineFieldsets.js
@@ -1,9 +1,11 @@
 jQuery(function($) {
-
     /// INLINE ELEMENTS
     /// collapsible elements for stacked inlines
     $('div.inline-stacked div.inline-related').each(function(i) {
-        $(this).addClass("collapsed");
+        if(!$(this).hasClass('collapse-open')){
+            $(this).addClass("collapsed");
+        }
+
         $(this).find('h3:first').attr("class", "collapse-toggle");
     });
     $('div.inline-stacked div.inline-related h3.collapse-toggle').bind("click", function(){

--- a/grappelli_safe/templates/admin/edit_inline/stacked.html
+++ b/grappelli_safe/templates/admin/edit_inline/stacked.html
@@ -13,7 +13,7 @@
     {{ inline_admin_formset.formset.non_form_errors }}
     <div class="items"> <!-- sortable container -->
         {% for inline_admin_form in inline_admin_formset %}
-        <div class="inline-related collapse-closed{% if inline_admin_form.original or inline_admin_form.show_url %} has_original{% endif %}{% if forloop.last %} empty-form{% endif %}"> <!-- sortable items -->
+        <div class="inline-related collapse-closed{% if inline_admin_form.original or inline_admin_form.show_url %} has_original{% endif %} {% if inline_admin_formset.opts.inline_classes %} {{ inline_admin_formset.opts.inline_classes|join:" " }}{% endif %}"> <!-- sortable items -->
             <!-- headline, original, delete/link/sort -->
             <h3>
                 {% for fieldset in inline_admin_form %}


### PR DESCRIPTION
the previous version of grappelli_safe didn't give you any way to open stacked inlines by default.  You can't even add a class to the list of items.  This adds the ability to use inline_classes and also not collapse if 'collapse-open' class is in that array.
