### PR TITLE
remove inappropriate try to focus first input field

### DIFF
--- a/grappelli_safe/templates/admin/change_form.html
+++ b/grappelli_safe/templates/admin/change_form.html
@@ -110,10 +110,6 @@
             <!-- Submit-Row -->
             {% block submit_buttons_bottom %}{% submit_row %}{% endblock %}
 
-            {% if add %}
-            <script type="text/javascript">document.getElementById("{{ adminform.first_field.auto_id }}").focus();</script>
-            {% endif %}
-
             <!-- JS for prepopulated fields -->
             {% prepopulated_fields_js %}
 


### PR DESCRIPTION
constantly throwing Uncaught TypeError: Cannot read property 'focus' of null.
Not looked around much, but it seems that the first input field gets the focus anyway.