### PR TITLE
Add {{ media }} rendering in delete views

### DIFF
--- a/grappelli_safe/templates/admin/delete_confirmation.html
+++ b/grappelli_safe/templates/admin/delete_confirmation.html
@@ -3,6 +3,12 @@
 <!-- LOADING -->
 {% load i18n admin_urls %}
 
+<!-- JAVASCRIPTS -->
+{% block javascripts %}
+    {{ block.super }}
+    {{ media }}
+{% endblock %}
+
 <!-- BREADCRUMBS -->
 {% block breadcrumbs %}
 <div class="breadcrumbs">

--- a/grappelli_safe/templates/admin/delete_selected_confirmation.html
+++ b/grappelli_safe/templates/admin/delete_selected_confirmation.html
@@ -3,6 +3,12 @@
 <!-- LOADING -->
 {% load i18n l10n %}
 
+<!-- JAVASCRIPTS -->
+{% block javascripts %}
+    {{ block.super }}
+    {{ media }}
+{% endblock %}
+
 <!-- BREADCRUMBS -->
 {% block breadcrumbs %}
 <div class="breadcrumbs">


### PR DESCRIPTION
Renders modeladmin media in delete views.

Django by default does this:
https://github.com/django/django/blob/master/django/contrib/admin/templates/admin/delete_confirmation.html#L5

https://github.com/django/django/blob/master/django/contrib/admin/templates/admin/delete_selected_confirmation.html#L5

I know grappelli_safe is not necessarily supposed to follow django's templates, but adding this adding this addition allows for additional overrides on the `delete_confirmation` and `delete_selected_confirmation` views.

Grappelli proper does not add this either:

https://github.com/sehmaschine/django-grappelli/blob/master/grappelli/templates/admin/delete_selected_confirmation.html


https://github.com/sehmaschine/django-grappelli/blob/master/grappelli/templates/admin/delete_confirmation.html

As such I am unaware if there is a specific reason it does not, but I figured better to try/ask and have it be denied than not try at all.