### PR TITLE
Drop template variable ordered_objects

### DIFF
--- a/grappelli_safe/templates/admin/change_form.html
+++ b/grappelli_safe/templates/admin/change_form.html
@@ -16,7 +16,7 @@
 {% endblock %}
 
 <!-- COLTYPE/BODYCLASS -->
-{% block coltype %}{% if ordered_objects %}colMS{% else %}colM{% endif %}{% endblock %}
+{% block coltype %}colM{% endblock %}
 {% block bodyclass %}{{ opts.app_label }}-{{ opts.object_name.lower }} change-form{% endblock %}
 
 <!-- BREADCRUMBS -->


### PR DESCRIPTION
Outdated template variable that hasn't been around since Django 1.5 so it can be safely dropped. Was dropped in commit for Django [ticket #19469](https://github.com/django/django/commit/d7b49f5b0dcecfcc9b5a77632ecbba88e7637490).