### PR TITLE
Correct text & background colors of selected calendar date

### DIFF
--- a/grappelli_safe/static/grappelli/css/widgets.css
+++ b/grappelli_safe/static/grappelli/css/widgets.css
@@ -241,7 +241,8 @@ a[id^="clocklink"]:hover, a[id^="clocklink"]:active {
     background: #fff;
 }
 
-.calendar td.selected a {
+.calendar td.selected a, .calendar td.today.selected a {
+    color: #fff;
     background: #444;
 }
 .calendar td.nonday {


### PR DESCRIPTION
When a date is selected, there is no contrast between the text color and the background:
![no-contrast](https://cloud.githubusercontent.com/assets/829401/17237226/9845aedc-551d-11e6-8d66-ced69cd2cce6.png)

When the selected date also happens to be today, the background does not indicate the selection:
![no-selection-today](https://cloud.githubusercontent.com/assets/829401/17237229/9ef8b9a4-551d-11e6-9631-cd06d2de0836.png)

This patch provides proper contrast for selected days, and allows today to be visually selected:
![contrast-and-today-selection](https://cloud.githubusercontent.com/assets/829401/17237234/a45e4b7a-551d-11e6-80f9-15c71e8f4067.png)
