### PR TITLE
Fixes an issue with inline formset pk hidden field being visible when it shouldn't be.

### DIFF
--- a/grappelli_safe/templates/admin/edit_inline/stacked.html
+++ b/grappelli_safe/templates/admin/edit_inline/stacked.html
@@ -37,7 +37,7 @@
             {% for fieldset in inline_admin_form %}
                 {% include "admin/includes/fieldset.html" %}
             {% endfor %}
-            {{ inline_admin_form.pk_field.field }}
+            {% if inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
             {{ inline_admin_form.fk_field.field }}
         </div>
         {% endfor %}

--- a/grappelli_safe/templates/admin/edit_inline/tabular.html
+++ b/grappelli_safe/templates/admin/edit_inline/tabular.html
@@ -66,7 +66,7 @@
                 </ul>
             </div>
             {{ inline_admin_form.fk_field.field }}
-            {{ inline_admin_form.pk_field.field }}
+            {% if inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
         </div>
         </div>
         {% endfor %}


### PR DESCRIPTION
Hide the inline auto pk field when the model primary key field is editable/in the form.