### PR TITLE
Style tel input fields the same as text/email/etc.

### DIFF
--- a/grappelli_safe/static/grappelli/css/forms.css
+++ b/grappelli_safe/static/grappelli/css/forms.css
@@ -170,6 +170,7 @@ input[type="text"],
 input[type="password"],
 input[type="email"],
 input[type="url"],
+input[type="tel"],
 input[type="number"] {
     padding: 5px 3px 4px;
     height: 14px;


### PR DESCRIPTION
Now that input[type="tel"] fields are becoming more common, this will style them the same as similar fields (namely in height & padding).

Fixes stephenmcd/grappelli-safe#99