### PR TITLE
Prevent recent actions from overflowing container

### DIFF
--- a/grappelli_safe/static/grappelli/css/dashboard.css
+++ b/grappelli_safe/static/grappelli/css/dashboard.css
@@ -130,6 +130,7 @@
 }
 .module ul.actionlist {
     padding-bottom: 3px;
+    overflow-x: auto;
 }
 ul.menulist li:last-child {
     border-bottom-color: #ddd;


### PR DESCRIPTION
Resort to horizontal-scrolling when content is long & non-breaking, such as a URL

Fixes stephenmcd/grappelli-safe#101