### PR TITLE
recover tz offset for admin

### DIFF
--- a/grappelli_safe/templates/admin/base.html
+++ b/grappelli_safe/templates/admin/base.html
@@ -23,7 +23,8 @@
 
 </head>
 
-<body class="{% if is_popup %}popup {% endif %}{% block bodyclass %}{% endblock %}">
+<body class="{% if is_popup %}popup {% endif %}{% block bodyclass %}{% endblock %}"
+  data-admin-utc-offset="{% now "Z" %}">
 
 <!-- CONTAINER -->
 <div id="container">


### PR DESCRIPTION
Time widget does not take offset into account when using a different zone in client/server. This is shown when 'now' link is pressed to fill current time.

I have backported the necessary attribute into the base.html template.